### PR TITLE
Add badges in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Vibi-DPU
+![Docker size](https://img.shields.io/docker/image-size/vibinexhub/dpu)
+![DPU commit activity](https://img.shields.io/github/commit-activity/y/vibinex/vibi-dpu)
+![DPU contributors](https://img.shields.io/github/contributors/vibinex/vibi-dpu)
 
 Vibi-DPU is an application written in Rust and packaged as a Docker image. It runs on the users' infrastructure to analyze private Intellectual Property data, empowering users through analysis without sacrificing privacy.
 


### PR DESCRIPTION
Add badges in README file: docker size, GitHub activity and number of contributors

Please check the action items covered in the PR - 

- [x] Build is running
- [ ] Eventing is functional and tested
- [ ] Unit or integration tests added and running
- [ ] Manual QA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to include new badges displaying Docker image size, commit activity, and contributors for the Vibi-DPU project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->